### PR TITLE
Change cli to colored output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1652,6 +1652,7 @@ dependencies = [
  "getopts",
  "log",
  "packsquash",
+ "terminal-emoji",
  "time 0.3.7",
  "tokio",
  "toml",
@@ -2278,6 +2279,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal-emoji"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8143568e8d5270b3b8f573ab8bb11a556a5c9e4becdc12241a7eef4c54a55170"
+dependencies = [
+ "terminal-supports-emoji",
+]
+
+[[package]]
+name = "terminal-supports-emoji"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8873a7a1f2d286cfedc10663a722309b1c74092852cf149aee738cbe901c6eb"
+dependencies = [
+ "atty",
+ "lazy_static",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,13 +1646,13 @@ dependencies = [
 name = "packsquash-cli"
 version = "0.3.1"
 dependencies = [
+ "atty",
  "color-backtrace",
  "crossterm",
  "env_logger",
  "getopts",
  "log",
  "packsquash",
- "terminal-emoji",
  "time 0.3.7",
  "tokio",
  "toml",
@@ -2279,25 +2279,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "terminal-emoji"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8143568e8d5270b3b8f573ab8bb11a556a5c9e4becdc12241a7eef4c54a55170"
-dependencies = [
- "terminal-supports-emoji",
-]
-
-[[package]]
-name = "terminal-supports-emoji"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8873a7a1f2d286cfedc10663a722309b1c74092852cf149aee738cbe901c6eb"
-dependencies = [
- "atty",
- "lazy_static",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,10 +684,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
- "atty",
- "humantime",
  "log",
- "regex",
  "termcolor",
 ]
 
@@ -1128,12 +1125,6 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "ident_case"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "fallible_collections"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,6 +1153,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "ident_case"
@@ -1629,7 +1648,9 @@ version = "0.3.1"
 dependencies = [
  "color-backtrace",
  "crossterm",
+ "env_logger",
  "getopts",
+ "log",
  "packsquash",
  "time 0.3.7",
  "tokio",

--- a/packages/packsquash-cli/Cargo.toml
+++ b/packages/packsquash-cli/Cargo.toml
@@ -23,7 +23,7 @@ color-backtrace = { version = "0.5.1", default-features = false, optional = true
 crossterm = { version = "0.22.1", optional = true }
 log = "0.4"
 env_logger = "0.9.0"
-terminal-emoji = "0.4.1"
+atty = "0.2.14"
 
 [build-dependencies]
 vergen = { version = "6.0.2", default-features = false, features = ["cargo", "git"] }

--- a/packages/packsquash-cli/Cargo.toml
+++ b/packages/packsquash-cli/Cargo.toml
@@ -21,6 +21,8 @@ tokio = { version = "1.16.1", default-features = false }
 
 color-backtrace = { version = "0.5.1", default-features = false, optional = true }
 crossterm = { version = "0.22.1", optional = true }
+log = "0.4"
+env_logger = "0.9.0"
 
 [build-dependencies]
 vergen = { version = "6.0.2", default-features = false, features = ["cargo", "git"] }

--- a/packages/packsquash-cli/Cargo.toml
+++ b/packages/packsquash-cli/Cargo.toml
@@ -24,7 +24,7 @@ color-backtrace = { version = "0.5.1", default-features = false, optional = true
 atty = "0.2.14"
 
 log = "0.4"
-env_logger = "0.9.0"
+env_logger = { version = "0.9.0", default-features = false, features = ["termcolor"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", default-features = false, features = ["consoleapi"] }

--- a/packages/packsquash-cli/Cargo.toml
+++ b/packages/packsquash-cli/Cargo.toml
@@ -23,6 +23,7 @@ color-backtrace = { version = "0.5.1", default-features = false, optional = true
 crossterm = { version = "0.22.1", optional = true }
 log = "0.4"
 env_logger = "0.9.0"
+terminal-emoji = "0.4.1"
 
 [build-dependencies]
 vergen = { version = "6.0.2", default-features = false, features = ["cargo", "git"] }

--- a/packages/packsquash-cli/src/main.rs
+++ b/packages/packsquash-cli/src/main.rs
@@ -133,7 +133,7 @@ fn read_options_file_and_squash(
 	title_controller: Option<TerminalTitleController>
 ) -> i32 {
 	let user_friendly_options_path =
-		options_file_path.map_or_else(|| "standard input (keyboard input or pipe)", |path| path);
+		options_file_path.map_or("standard input (keyboard input or pipe)", |path| path);
 
 	// Tell the user where are we reading the configuration from
 	info!(

--- a/packages/packsquash-cli/src/main.rs
+++ b/packages/packsquash-cli/src/main.rs
@@ -424,13 +424,14 @@ fn print_version_information(verbose: bool) {
 /// application operation information.
 fn init_logger(mut enable_emoji: bool, enable_colors: bool) {
 	let mut logger_builder = Builder::new();
+	let log_target_is_tty = atty::is(atty::Stream::Stderr);
 
 	// Only enable emojis if they are going to be logged to an interactive terminal
-	enable_emoji = enable_emoji && atty::is(atty::Stream::Stderr);
+	enable_emoji = enable_emoji && log_target_is_tty;
 
 	logger_builder
 		.target(Target::Stderr)
-		.write_style(if enable_colors && atty::is(atty::Stream::Stderr) {
+		.write_style(if enable_colors && log_target_is_tty {
 			WriteStyle::Always
 		} else {
 			WriteStyle::Never

--- a/packages/packsquash-cli/src/main.rs
+++ b/packages/packsquash-cli/src/main.rs
@@ -408,7 +408,7 @@ fn formatted_builder(enable_emoji: bool) -> Builder {
 		let (color, icon) = match record.level() {
 			Level::Error => (Color::Red, if enable_emoji { "❌" } else { "!" }),
 			Level::Warn => (Color::Yellow, if enable_emoji { "⚡️" } else { "*" }),
-			Level::Info => (Color::Cyan, if enable_emoji { "🔔" } else { "-" }),
+			Level::Info => (Color::Cyan, if enable_emoji { "🔎" } else { "-" }),
 			Level::Debug => (Color::Green, if enable_emoji { "🍀" } else { "#" }),
 			Level::Trace => (Color::White, if enable_emoji { "🏁" } else { ">" })
 		};

--- a/packages/packsquash-cli/src/main.rs
+++ b/packages/packsquash-cli/src/main.rs
@@ -67,13 +67,18 @@ fn run() -> i32 {
 
 				0
 			} else {
+				let enable_color = if enable_color_default {
+					!option_matches.opt_present("no-color")
+				} else {
+					option_matches.opt_present("color")
+				};
 				// Treat --emoji as --emoji=true
 				let enable_emoji = match option_matches.opt_default("emoji", "true") {
 					Some(emoji) => {
 						match emoji.parse::<bool>() {
 							Ok(enable) => enable,
 							Err(parse_err) => {
-								init_logger(enable_emoji_default, enable_color_default);
+								init_logger(enable_emoji_default, enable_color);
 
 								error!("emoji: {}", parse_err);
 
@@ -82,11 +87,6 @@ fn run() -> i32 {
 						}
 					}
 					None => enable_emoji_default,
-				};
-				let enable_color = if enable_color_default {
-					!option_matches.opt_present("no-color")
-				} else {
-					option_matches.opt_present("color")
 				};
 				init_logger(enable_emoji, enable_color);
 

--- a/packages/packsquash-cli/src/main.rs
+++ b/packages/packsquash-cli/src/main.rs
@@ -231,14 +231,14 @@ fn squash(squash_options: SquashOptions) -> Result<Option<(u64, u64)>, PackSquas
 							ResetColor
 						),
 						None => {
-							let prefix = if pack_file_status.skipped() {
+							let color = if pack_file_status.skipped() {
 								SetForegroundColor(Color::Yellow)
 							} else {
 								SetForegroundColor(Color::Reset)
 							};
 							eprintln!(
 								"{}> {}: {}{}",
-								prefix,
+								color,
 								pack_file_status.path().as_str(),
 								pack_file_status.optimization_strategy(),
 								ResetColor

--- a/packages/packsquash-cli/src/main.rs
+++ b/packages/packsquash-cli/src/main.rs
@@ -407,7 +407,7 @@ fn formatted_builder(enable_emoji: bool) -> Builder {
 		let mut style = f.style();
 		let (color, icon) = match record.level() {
 			Level::Error => (Color::Red, if enable_emoji { "❌" } else { "!" }),
-			Level::Warn => (Color::Yellow, if enable_emoji { "👉" } else { "*" }),
+			Level::Warn => (Color::Yellow, if enable_emoji { "⚡️" } else { "*" }),
 			Level::Info => (Color::Cyan, if enable_emoji { "🔔" } else { "-" }),
 			Level::Debug => (Color::Green, if enable_emoji { "🍀" } else { "#" }),
 			Level::Trace => (Color::White, if enable_emoji { "🏁" } else { ">" })

--- a/packages/packsquash-cli/src/main.rs
+++ b/packages/packsquash-cli/src/main.rs
@@ -44,7 +44,8 @@ fn run() -> i32 {
 
 	options.optflag("h", "help", "Prints information about the command line arguments accepted by this application and exits")
 		.optflag("v", "version", "Prints version and copyright information of the application, then exits")
-		.optflagopt("", "emoji", &*format!("Enable emoji in output (default: {})", enable_emoji_default), "true/false")
+		.optflag("", "emoji", "Enable emoji in output")
+		.optflag("", "no-emoji", "Disable emoji in output")
 		.optflag("", "color", "Enable color in output")
 		.optflag("", "no-color", "Disable color in output")
 		.parsing_style(ParsingStyle::StopAtFirstFree);
@@ -67,24 +68,15 @@ fn run() -> i32 {
 
 				0
 			} else {
+				let enable_emoji = if enable_emoji_default {
+					!option_matches.opt_present("no-emoji")
+				} else {
+					option_matches.opt_present("emoji")
+				};
 				let enable_color = if enable_color_default {
 					!option_matches.opt_present("no-color")
 				} else {
 					option_matches.opt_present("color")
-				};
-				// Treat --emoji as --emoji=true
-				let enable_emoji = match option_matches.opt_default("emoji", "true") {
-					Some(emoji) => match emoji.parse::<bool>() {
-						Ok(enable) => enable,
-						Err(parse_err) => {
-							init_logger(enable_emoji_default, enable_color);
-
-							error!("emoji: {}", parse_err);
-
-							return 1;
-						}
-					},
-					None => enable_emoji_default
 				};
 				init_logger(enable_emoji, enable_color);
 

--- a/packages/packsquash-cli/src/main.rs
+++ b/packages/packsquash-cli/src/main.rs
@@ -146,7 +146,10 @@ fn read_options_file_and_squash(options_file_path: Option<&String>) -> i32 {
 
 	squash(squash_options).map_or_else(
 		|err| {
-			eprintln!("{}! Pack processing error: {}{}", CLI_COLOR_RED, err, CLI_COLOR_DEFAULT);
+			eprintln!(
+				"{}! Pack processing error: {}{}",
+				CLI_COLOR_RED, err, CLI_COLOR_DEFAULT
+			);
 
 			// We print both informational and error pack file status updates.
 			// If the error was in one of those, hint the user at the status
@@ -256,7 +259,9 @@ fn squash(squash_options: SquashOptions) -> Result<Option<(u64, u64)>, PackSquas
 						TerminalTitle::Finishing.show();
 					}
 				}
-				PackSquasherStatus::Notice(notice) => eprintln!("{}- {}{}", CLI_COLOR_CYAN, notice, CLI_COLOR_DEFAULT),
+				PackSquasherStatus::Notice(notice) => {
+					eprintln!("{}- {}{}", CLI_COLOR_CYAN, notice, CLI_COLOR_DEFAULT)
+				}
 				PackSquasherStatus::Warning(warning) => match warning {
 					PackSquasherWarning::UnusablePreviousZip(err) => eprintln!(
 						"{}* The previous ZIP file could not be read. It will not be used to speed up processing. \

--- a/packages/packsquash-cli/src/main.rs
+++ b/packages/packsquash-cli/src/main.rs
@@ -48,13 +48,13 @@ fn run() -> i32 {
 		Ok(option_matches) => {
 			if option_matches.opt_present("h") {
 				print_version_information(true);
-				trace!("");
-				trace!("Usage:");
-				trace!(
-					"    {} [OPTION]... [options file path]{}",
-					env!("CARGO_BIN_NAME"),
-					options.usage("")
+				println!();
+				println!("Usage:");
+				print!(
+					"    {} [OPTION]... [options file path]",
+					env!("CARGO_BIN_NAME")
 				);
+				println!("{}", options.usage(""));
 
 				0
 			} else if option_matches.opt_present("v") {
@@ -290,7 +290,7 @@ fn squash(squash_options: SquashOptions) -> Result<Option<(u64, u64)>, PackSquas
 
 /// Prints PackSquash version information to the standard output stream.
 fn print_version_information(verbose: bool) {
-	trace!(
+	println!(
 		"{} {} ({}, {}) for {}",
 		packsquash_title!(),
 		env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT"),
@@ -298,33 +298,33 @@ fn print_version_information(verbose: bool) {
 		env!("BUILD_DATE"),
 		env!("VERGEN_CARGO_TARGET_TRIPLE")
 	);
-	trace!("{}", env!("CARGO_PKG_DESCRIPTION"));
-	trace!("");
+	println!("{}", env!("CARGO_PKG_DESCRIPTION"));
+	println!();
 
 	if verbose {
-		trace!(
+		println!(
 			"Copyright (C) {} {}",
 			env!("BUILD_YEAR"),
 			env!("CARGO_PKG_AUTHORS")
 		);
-		trace!("");
-		trace!("This program is free software: you can redistribute it and/or modify");
-		trace!("it under the terms of the GNU Affero General Public License as");
-		trace!("published by the Free Software Foundation, either version 3 of the");
-		trace!("License, or (at your option) any later version.");
-		trace!("");
-		trace!("This program is distributed free of charge in the hope that it will");
-		trace!("be useful, but WITHOUT ANY WARRANTY; without even the implied warranty");
-		trace!("of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the");
-		trace!("GNU Affero General Public License for more details.");
-		trace!("");
-		trace!("You should have received a copy of the GNU Affero General Public License");
-		trace!("along with this program. If not, see <https://www.gnu.org/licenses/>.");
+		println!();
+		println!("This program is free software: you can redistribute it and/or modify");
+		println!("it under the terms of the GNU Affero General Public License as");
+		println!("published by the Free Software Foundation, either version 3 of the");
+		println!("License, or (at your option) any later version.");
+		println!();
+		println!("This program is distributed free of charge in the hope that it will");
+		println!("be useful, but WITHOUT ANY WARRANTY; without even the implied warranty");
+		println!("of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the");
+		println!("GNU Affero General Public License for more details.");
+		println!();
+		println!("You should have received a copy of the GNU Affero General Public License");
+		println!("along with this program. If not, see <https://www.gnu.org/licenses/>.");
 	} else {
-		trace!("This program comes with ABSOLUTELY NO WARRANTY.");
-		trace!("This is free software, and you are welcome to redistribute it");
-		trace!("under certain conditions. Use the -v command line switch for");
-		trace!("more details about these conditions.");
+		println!("This program comes with ABSOLUTELY NO WARRANTY.");
+		println!("This is free software, and you are welcome to redistribute it");
+		println!("under certain conditions. Use the -v command line switch for");
+		println!("more details about these conditions.");
 	}
 }
 

--- a/packages/packsquash-cli/src/main.rs
+++ b/packages/packsquash-cli/src/main.rs
@@ -51,10 +51,10 @@ fn run() -> i32 {
 				trace!("");
 				trace!("Usage:");
 				trace!(
-					"    {} [OPTION]... [options file path]",
-					env!("CARGO_BIN_NAME")
+					"    {} [OPTION]... [options file path]{}",
+					env!("CARGO_BIN_NAME"),
+					options.usage("")
 				);
-				trace!("{}", options.usage(""));
 
 				0
 			} else if option_matches.opt_present("v") {

--- a/packages/packsquash-cli/src/main.rs
+++ b/packages/packsquash-cli/src/main.rs
@@ -16,8 +16,10 @@ use packsquash::{
 	config::SquashOptions, vfs::os_fs::OsFilesystem, PackSquasher, PackSquasherError,
 	PackSquasherStatus, PackSquasherWarning
 };
+use terminal_style::{environment_allows_color, environment_allows_emoji};
 use terminal_title_controller::TerminalTitleController;
 
+mod terminal_style;
 mod terminal_title_controller;
 mod terminal_title_setter;
 
@@ -418,6 +420,8 @@ fn print_version_information(verbose: bool) {
 	}
 }
 
+/// Initializes the logging of the application, responsible of showing to the user relevant
+/// application operation information.
 fn init_logger(mut enable_emoji: bool, enable_colors: bool) {
 	let mut logger_builder = Builder::new();
 
@@ -462,62 +466,4 @@ fn init_logger(mut enable_emoji: bool, enable_colors: bool) {
 	}
 
 	logger_builder.init();
-}
-
-fn terminal_can_display_color() -> bool {
-	let term = env::var_os("TERM");
-	let term_is_dumb = |term| term != "dumb" && term != "unknown";
-
-	term.map_or(
-		// On Unix-like platforms, TERM must be set, or else things are probably
-		// broken and colors won't work. On Windows and other platforms that is not
-		// the case. We assume that if the terminal is not dumb then colors are supported
-		cfg!(unix),
-		term_is_dumb
-	)
-}
-
-fn environment_allows_color() -> bool {
-	if let Some(color_mode) = env::var_os("PACKSQUASH_COLOR").or_else(|| env::var_os("COLOR")) {
-		// The PACKSQUASH_COLOR and COLOR environment variables, in that priority order,
-		// allow overriding any decision made
-		color_mode == "show"
-	} else if env::var_os("NO_COLOR").is_some() {
-		// The NO_COLOR environment variable allows disabling color no matter what
-		false
-	} else {
-		// Otherwise, if no special environment variable is set, just check if the
-		// terminal can reliably display color
-		terminal_can_display_color()
-	}
-}
-
-fn terminal_can_display_emoji() -> bool {
-	if cfg!(windows) {
-		// On Windows, the new Windows Terminal and Unix-like terminals support emojis.
-		// Any sane Windows install has fonts set up in a way that will show emojis
-		env::var_os("WT_SESSION").is_some() || env::var_os("TERM").is_some()
-	} else {
-		// Only macOS reliably supports emojis. UTF-8 support is almost universal on Unixes,
-		// but the monospaced fonts used in terminal emulators usually do not contain emojis,
-		// and the fallback to fonts that contain them requires a cooperative terminal emulator
-		// and is brittle. It may be necessary to tweak fontconfig files in a way that does not
-		// break anything else. See: https://gist.github.com/IgnoredAmbience/7c99b6cf9a8b73c9312a71d1209d9bbb
-		cfg!(target_os = "macos")
-	}
-}
-
-fn environment_allows_emoji() -> bool {
-	if let Some(emoji_mode) = env::var_os("PACKSQUASH_EMOJI").or_else(|| env::var_os("EMOJI")) {
-		// The PACKSQUASH_EMOJI and EMOJI environment variables, in that priority order,
-		// allow overriding any decision made
-		emoji_mode == "show"
-	} else if env::var_os("NO_EMOJI").is_some() {
-		// The NO_EMOJI environment variable allows disabling emojis no matter what
-		false
-	} else {
-		// Otherwise, if no special environment variable is set, just check if the
-		// terminal can reliably display emojis
-		terminal_can_display_emoji()
-	}
 }

--- a/packages/packsquash-cli/src/main.rs
+++ b/packages/packsquash-cli/src/main.rs
@@ -1,3 +1,4 @@
+use crossterm::style::{Color, ResetColor, SetForegroundColor};
 use std::{
 	borrow::Cow,
 	env, fs,
@@ -5,7 +6,6 @@ use std::{
 	process, thread,
 	time::Instant
 };
-use crossterm::style::{Color, ResetColor, SetForegroundColor};
 
 use getopts::{Options, ParsingStyle};
 use tokio::sync::mpsc::channel;
@@ -67,7 +67,12 @@ fn run() -> i32 {
 			}
 		}
 		Err(parse_err) => {
-			eprintln!("{}{}{}", SetForegroundColor(Color::Red), parse_err, ResetColor);
+			eprintln!(
+				"{}{}{}",
+				SetForegroundColor(Color::Red),
+				parse_err,
+				ResetColor
+			);
 			eprintln!(
 				"{}Run {} -h to see command line argument help{}",
 				SetForegroundColor(Color::Red),
@@ -113,7 +118,10 @@ fn read_options_file_and_squash(options_file_path: Option<&String>) -> i32 {
 		Err(err) => {
 			eprintln!(
 				"{}! Couldn't read the options file from {}: {}{}",
-				SetForegroundColor(Color::Red), user_friendly_options_path, err, ResetColor
+				SetForegroundColor(Color::Red),
+				user_friendly_options_path,
+				err,
+				ResetColor
 			);
 
 			return 2;
@@ -126,7 +134,10 @@ fn read_options_file_and_squash(options_file_path: Option<&String>) -> i32 {
 		Err(deserialize_error) => {
 			eprintln!(
 				"{}! An error occurred while parsing the options file from {}: {}{}",
-				SetForegroundColor(Color::Red), user_friendly_options_path, deserialize_error, ResetColor
+				SetForegroundColor(Color::Red),
+				user_friendly_options_path,
+				deserialize_error,
+				ResetColor
 			);
 
 			return 3;
@@ -143,7 +154,9 @@ fn read_options_file_and_squash(options_file_path: Option<&String>) -> i32 {
 		|err| {
 			eprintln!(
 				"{}! Pack processing error: {}{}",
-				SetForegroundColor(Color::Red), err, ResetColor
+				SetForegroundColor(Color::Red),
+				err,
+				ResetColor
 			);
 
 			// We print both informational and error pack file status updates.
@@ -153,14 +166,16 @@ fn read_options_file_and_squash(options_file_path: Option<&String>) -> i32 {
 				eprintln!(
 					"{}Another error message with more details about the error was emitted before. \
 					You might need to scroll up to see it.{}",
-					SetForegroundColor(Color::Red), ResetColor
+					SetForegroundColor(Color::Red),
+					ResetColor
 				);
 			}
 
 			eprintln!(
 				"{}These troubleshooting instructions might be useful: \
 				<https://packsquash.page.link/Troubleshooting-pack-processing-errors>{}",
-				SetForegroundColor(Color::Red), ResetColor
+				SetForegroundColor(Color::Red),
+				ResetColor
 			);
 
 			128
@@ -255,7 +270,12 @@ fn squash(squash_options: SquashOptions) -> Result<Option<(u64, u64)>, PackSquas
 					}
 				}
 				PackSquasherStatus::Notice(notice) => {
-					eprintln!("{}- {}{}", SetForegroundColor(Color::Cyan), notice, ResetColor)
+					eprintln!(
+						"{}- {}{}",
+						SetForegroundColor(Color::Cyan),
+						notice,
+						ResetColor
+					)
 				}
 				PackSquasherStatus::Warning(warning) => match warning {
 					PackSquasherWarning::UnusablePreviousZip(err) => eprintln!(

--- a/packages/packsquash-cli/src/main.rs
+++ b/packages/packsquash-cli/src/main.rs
@@ -74,19 +74,17 @@ fn run() -> i32 {
 				};
 				// Treat --emoji as --emoji=true
 				let enable_emoji = match option_matches.opt_default("emoji", "true") {
-					Some(emoji) => {
-						match emoji.parse::<bool>() {
-							Ok(enable) => enable,
-							Err(parse_err) => {
-								init_logger(enable_emoji_default, enable_color);
+					Some(emoji) => match emoji.parse::<bool>() {
+						Ok(enable) => enable,
+						Err(parse_err) => {
+							init_logger(enable_emoji_default, enable_color);
 
-								error!("emoji: {}", parse_err);
+							error!("emoji: {}", parse_err);
 
-								return 1;
-							}
+							return 1;
 						}
-					}
-					None => enable_emoji_default,
+					},
+					None => enable_emoji_default
 				};
 				init_logger(enable_emoji, enable_color);
 

--- a/packages/packsquash-cli/src/main.rs
+++ b/packages/packsquash-cli/src/main.rs
@@ -44,7 +44,7 @@ fn run() -> i32 {
 
 	options.optflag("h", "help", "Prints information about the command line arguments accepted by this application and exits")
 		.optflag("v", "version", "Prints version and copyright information of the application, then exits")
-		.optflagopt("e", "emoji", &*format!("Enable emoji in output (default: {})", enable_emoji_default), "true/false")
+		.optflagopt("", "emoji", &*format!("Enable emoji in output (default: {})", enable_emoji_default), "true/false")
 		.optflag("", "color", "Enable color in output")
 		.optflag("", "no-color", "Disable color in output")
 		.parsing_style(ParsingStyle::StopAtFirstFree);
@@ -67,7 +67,7 @@ fn run() -> i32 {
 
 				0
 			} else {
-				match option_matches.opt_get_default("e", enable_emoji_default) {
+				match option_matches.opt_get_default("emoji", enable_emoji_default) {
 					Ok(enable_emoji) => {
 						let enable_color = if enable_color_default {
 							!option_matches.opt_present("no-color")

--- a/packages/packsquash-cli/src/main.rs
+++ b/packages/packsquash-cli/src/main.rs
@@ -10,6 +10,7 @@ use std::{
 
 use getopts::{Options, ParsingStyle};
 use log::{debug, error, info, trace, warn, Level, LevelFilter};
+use terminal_emoji::Emoji;
 use tokio::sync::mpsc::channel;
 
 use packsquash::{
@@ -387,11 +388,11 @@ fn formatted_builder() -> Builder {
 
 		let mut style = f.style();
 		let (color, icon) = match record.level() {
-			Level::Error => (Color::Red, "!"),
-			Level::Warn => (Color::Yellow, "*"),
-			Level::Info => (Color::Cyan, "-"),
-			Level::Debug => (Color::Green, "#"),
-			Level::Trace => (Color::White, ">")
+			Level::Error => (Color::Red, Emoji::new("❌", "!")),
+			Level::Warn => (Color::Yellow, Emoji::new("👉", "*")),
+			Level::Info => (Color::Cyan, Emoji::new("🔔", "-")),
+			Level::Debug => (Color::Green, Emoji::new("🍀", "#")),
+			Level::Trace => (Color::White, Emoji::new("🏁", ">"))
 		};
 		let message = style
 			.set_color(color)

--- a/packages/packsquash-cli/src/terminal_style.rs
+++ b/packages/packsquash-cli/src/terminal_style.rs
@@ -1,0 +1,63 @@
+use std::env;
+
+fn terminal_can_display_color() -> bool {
+	let term = env::var_os("TERM");
+	let term_is_dumb = |term| term != "dumb" && term != "unknown";
+
+	term.map_or(
+		// On Unix-like platforms, TERM must be set, or else things are probably
+		// broken and colors won't work. On Windows and other platforms that is not
+		// the case. We assume that if the terminal is not dumb then colors are supported
+		cfg!(unix),
+		term_is_dumb
+	)
+}
+
+/// Checks whether the running environment (i.e. terminal and environment variables combination)
+/// allows displaying color.
+pub fn environment_allows_color() -> bool {
+	if let Some(color_mode) = env::var_os("PACKSQUASH_COLOR").or_else(|| env::var_os("COLOR")) {
+		// The PACKSQUASH_COLOR and COLOR environment variables, in that priority order,
+		// allow overriding any decision made
+		color_mode == "show"
+	} else if env::var_os("NO_COLOR").is_some() {
+		// The NO_COLOR environment variable allows disabling color no matter what
+		false
+	} else {
+		// Otherwise, if no special environment variable is set, just check if the
+		// terminal can reliably display color
+		terminal_can_display_color()
+	}
+}
+
+fn terminal_can_display_emoji() -> bool {
+	if cfg!(windows) {
+		// On Windows, the new Windows Terminal and Unix-like terminals support emojis.
+		// Any sane Windows install has fonts set up in a way that will show emojis
+		env::var_os("WT_SESSION").is_some() || env::var_os("TERM").is_some()
+	} else {
+		// Only macOS reliably supports emojis. UTF-8 support is almost universal on Unixes,
+		// but the monospaced fonts used in terminal emulators usually do not contain emojis,
+		// and the fallback to fonts that contain them requires a cooperative terminal emulator
+		// and is brittle. It may be necessary to tweak fontconfig files in a way that does not
+		// break anything else. See: https://gist.github.com/IgnoredAmbience/7c99b6cf9a8b73c9312a71d1209d9bbb
+		cfg!(target_os = "macos")
+	}
+}
+
+/// Checks whether the running environment (i.e. terminal and environment variables combination)
+/// allows displaying emoji.
+pub fn environment_allows_emoji() -> bool {
+	if let Some(emoji_mode) = env::var_os("PACKSQUASH_EMOJI").or_else(|| env::var_os("EMOJI")) {
+		// The PACKSQUASH_EMOJI and EMOJI environment variables, in that priority order,
+		// allow overriding any decision made
+		emoji_mode == "show"
+	} else if env::var_os("NO_EMOJI").is_some() {
+		// The NO_EMOJI environment variable allows disabling emojis no matter what
+		false
+	} else {
+		// Otherwise, if no special environment variable is set, just check if the
+		// terminal can reliably display emojis
+		terminal_can_display_emoji()
+	}
+}

--- a/packages/packsquash-cli/src/terminal_style.rs
+++ b/packages/packsquash-cli/src/terminal_style.rs
@@ -8,7 +8,7 @@ fn terminal_can_display_color() -> bool {
 		// On Unix-like platforms, TERM must be set, or else things are probably
 		// broken and colors won't work. On Windows and other platforms that is not
 		// the case. We assume that if the terminal is not dumb then colors are supported
-		cfg!(unix),
+		cfg!(not(unix)),
 		term_is_dumb
 	)
 }

--- a/packages/packsquash-cli/src/terminal_style.rs
+++ b/packages/packsquash-cli/src/terminal_style.rs
@@ -14,7 +14,8 @@ fn terminal_can_display_color() -> bool {
 }
 
 /// Checks whether the running environment (i.e. terminal and environment variables combination)
-/// allows displaying color.
+/// allows displaying color. This does not take into account whether any output will actually
+/// go to an interactive terminal.
 pub fn environment_allows_color() -> bool {
 	if let Some(color_mode) = env::var_os("PACKSQUASH_COLOR").or_else(|| env::var_os("COLOR")) {
 		// The PACKSQUASH_COLOR and COLOR environment variables, in that priority order,
@@ -46,7 +47,8 @@ fn terminal_can_display_emoji() -> bool {
 }
 
 /// Checks whether the running environment (i.e. terminal and environment variables combination)
-/// allows displaying emoji.
+/// allows displaying emoji. This does not take into account whether any output will actually
+/// go to an interactive terminal.
 pub fn environment_allows_emoji() -> bool {
 	if let Some(emoji_mode) = env::var_os("PACKSQUASH_EMOJI").or_else(|| env::var_os("EMOJI")) {
 		// The PACKSQUASH_EMOJI and EMOJI environment variables, in that priority order,

--- a/packages/packsquash-cli/src/terminal_title_setter.rs
+++ b/packages/packsquash-cli/src/terminal_title_setter.rs
@@ -40,5 +40,10 @@ fn write_ansi_set_window_title_escape_sequence<W: Write>(mut w: W, string: &str)
 	// OSC = ESC ]
 	// Ps = 2 = Change Window Title to Pt
 	// OSC Ps ; Pt BEL
+	// See: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Tektronix-4014-Mode
 	write!(w, "\x1B]2;{}\x07", string).ok();
+
+	// Flushing is needed because the stream may be (line-)buffered, preventing
+	// the title from being updated promptly
+	w.flush().ok();
 }


### PR DESCRIPTION
## Changes

Makes message output more usable and better. ~~I'd like to have the `--no-color` option, but I haven't implemented it.~~

![](https://user-images.githubusercontent.com/34268371/150290134-f0ff56f2-45ad-4713-86c0-7f6f29be93ed.png)
![](https://user-images.githubusercontent.com/34268371/150290152-b01fa561-d55c-440b-8f31-8951d366f0b7.png)

## Test

<details>
<summary>config.toml</summary>

```toml
pack_directory="pack"
```

</details>

<details>
<summary>config_9000.toml</summary>

```toml
pack_directory="pack"

['**/*.png']
maximum_width_and_height=9000
```

</details>

And some dummy images in `assets/minecraft/textures`.

[Download as zip](https://github.com/ComunidadAylas/PackSquash/files/7903012/test.zip)
