### PR TITLE
fix: Change to be able to use colors and emojis in GitHub Actions

### DIFF
--- a/packages/packsquash-cli/src/main.rs
+++ b/packages/packsquash-cli/src/main.rs
@@ -44,8 +44,8 @@ fn run(title_controller: Option<TerminalTitleController>) -> i32 {
 	}
 
 	let log_target_is_tty = atty::is(LOG_TARGET_STREAM);
-	let enable_emoji_default = environment_allows_emoji() && log_target_is_tty;
-	let enable_color_default = environment_allows_color() && log_target_is_tty;
+	let enable_emoji_default = environment_allows_emoji(log_target_is_tty);
+	let enable_color_default = environment_allows_color(log_target_is_tty);
 
 	let mut options = Options::new();
 

--- a/packages/packsquash-cli/src/terminal_style.rs
+++ b/packages/packsquash-cli/src/terminal_style.rs
@@ -14,9 +14,8 @@ fn terminal_can_display_color() -> bool {
 }
 
 /// Checks whether the running environment (i.e. terminal and environment variables combination)
-/// allows displaying color. This does not take into account whether any output will actually
-/// go to an interactive terminal.
-pub fn environment_allows_color() -> bool {
+/// allows displaying color.
+pub fn environment_allows_color(is_tty: bool) -> bool {
 	if let Some(color_mode) = env::var_os("PACKSQUASH_COLOR").or_else(|| env::var_os("COLOR")) {
 		// The PACKSQUASH_COLOR and COLOR environment variables, in that priority order,
 		// allow overriding any decision made
@@ -27,7 +26,7 @@ pub fn environment_allows_color() -> bool {
 	} else {
 		// Otherwise, if no special environment variable is set, just check if the
 		// terminal can reliably display color
-		terminal_can_display_color()
+		is_tty && terminal_can_display_color()
 	}
 }
 
@@ -47,9 +46,8 @@ fn terminal_can_display_emoji() -> bool {
 }
 
 /// Checks whether the running environment (i.e. terminal and environment variables combination)
-/// allows displaying emoji. This does not take into account whether any output will actually
-/// go to an interactive terminal.
-pub fn environment_allows_emoji() -> bool {
+/// allows displaying emoji.
+pub fn environment_allows_emoji(is_tty: bool) -> bool {
 	if let Some(emoji_mode) = env::var_os("PACKSQUASH_EMOJI").or_else(|| env::var_os("EMOJI")) {
 		// The PACKSQUASH_EMOJI and EMOJI environment variables, in that priority order,
 		// allow overriding any decision made
@@ -60,6 +58,6 @@ pub fn environment_allows_emoji() -> bool {
 	} else {
 		// Otherwise, if no special environment variable is set, just check if the
 		// terminal can reliably display emojis
-		terminal_can_display_emoji()
+		is_tty && terminal_can_display_emoji()
 	}
 }


### PR DESCRIPTION
## Current

![](https://user-images.githubusercontent.com/34268371/152620922-f0d76459-5e2f-42da-909d-4f56df2421a3.png)

Look 1345-1346. `PACKSQUASH_COLOR`, `PACKSQUASH_EMOJI` are set.
However, emojis and colors are not enabled.

## Change

Don't overwrite env var by is_tty.