### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/packages/packsquash/src/pack_file/command_function_file.rs
+++ b/packages/packsquash/src/pack_file/command_function_file.rs
@@ -28,7 +28,7 @@ mod tests;
 /// to read these files.
 ///
 /// References:
-/// - <https://minecraft.fandom.com/wiki/Function_(Java_Edition)>
+/// - <https://minecraft.wiki/w/Function_(Java_Edition)>
 /// - Minecraft class `net.minecraft.commands.CommandFunction`
 pub struct CommandFunctionFile<T: AsyncRead + Send + Unpin + 'static> {
 	read: T,

--- a/packages/packsquash/src/pack_file/legacy_lang_file.rs
+++ b/packages/packsquash/src/pack_file/legacy_lang_file.rs
@@ -53,7 +53,7 @@ static FORMAT_SPECIFIER_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 /// files in Minecraft 1.13. Only Minecraft 1.12 and older versions use this type of files.
 ///
 /// References:
-/// - <https://minecraft.fandom.com/wiki/Resource_Pack?oldid=1257552#Language>
+/// - <https://minecraft.wiki/w/Resource_Pack?oldid=1257552#Language>
 /// - Minecraft class `net.minecraft.client.resources.Locale` (MCP 1.12.2 name)
 /// - OpenJDK 11 implementation of class `java.util.Formatter`
 pub struct LegacyLanguageFile<T: AsyncRead + Send + Unpin + 'static> {

--- a/packages/packsquash/src/pack_meta.rs
+++ b/packages/packsquash/src/pack_meta.rs
@@ -28,8 +28,8 @@ pub const PACK_FORMAT_VERSION_1_17: i32 = 7;
 /// `pack.mcmetac` file in the root folder of a pack.
 ///
 /// References:
-/// - <https://minecraft.fandom.com/wiki/Resource_Pack#Contents>
-/// - <https://minecraft.fandom.com/wiki/Data_Pack#pack.mcmeta>
+/// - <https://minecraft.wiki/w/Resource_Pack#Contents>
+/// - <https://minecraft.wiki/w/Data_Pack#pack.mcmeta>
 /// - Minecraft class `net.minecraft.server.packs.metadata.pack.PackMetadataSectionSerializer`
 pub struct PackMeta {
 	pack_format_version: i32


### PR DESCRIPTION
## Motivation and purpose

The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. 

## Description

This PR updates all fandom wiki URLs accordingly.
