### PR TITLE
[0.5.0] Update Minecraft wiki links to new domain

### DIFF
--- a/packages/packsquash/src/pack_processor/java/asset_processor/blockstate_asset_processor/blockstate.rs
+++ b/packages/packsquash/src/pack_processor/java/asset_processor/blockstate_asset_processor/blockstate.rs
@@ -16,7 +16,7 @@ use crate::util::zero_copy_deserialize_traits::ZeroCopyDeserializable;
 
 /// References:
 /// - Vanilla deserializer: `net.minecraft.client.renderer.block.model.BlockModelDefinition`
-/// - https://minecraft.fandom.com/wiki/Tutorials/Models#Block_states
+/// - https://minecraft.wiki/w/Tutorials/Models#Block_states
 #[derive(Debug, Deserialize, Serialize)]
 pub(super) struct BlockState<'data> {
 	// TODO docs: must be present if not multipart. The game falls back silently if some variant is

--- a/packages/packsquash/src/pack_processor/java/asset_processor/item_and_block_model_asset_processor/item_or_block_model.rs
+++ b/packages/packsquash/src/pack_processor/java/asset_processor/item_and_block_model_asset_processor/item_or_block_model.rs
@@ -31,8 +31,8 @@ use crate::{
 ///   (used for both item and block models)
 /// - `net.minecraft.client.resources.model.ModelBakery#BUILTIN_*`
 ///   (look at `GENERATION_MARKER` and `BLOCK_ENTITY_MARKER` usages at `ModelBakery`)
-/// - https://minecraft.fandom.com/wiki/Tutorials/Models#Block_models
-/// - https://minecraft.fandom.com/wiki/Tutorials/Models#Item_models
+/// - https://minecraft.wiki/w/Tutorials/Models#Block_models
+/// - https://minecraft.wiki/w/Tutorials/Models#Item_models
 #[derive(Debug, Deserialize, Serialize)]
 pub(super) struct ItemOrBlockModel<'data> {
 	/// The location of the parent model of this model.

--- a/packages/packsquash/src/pack_processor/java/pack_meta.rs
+++ b/packages/packsquash/src/pack_processor/java/pack_meta.rs
@@ -37,8 +37,8 @@ mod metadata_section;
 /// root folder of a pack.
 ///
 /// References:
-/// - <https://minecraft.fandom.com/wiki/Resource_Pack#Contents>
-/// - <https://minecraft.fandom.com/wiki/Data_Pack#pack.mcmeta>
+/// - <https://minecraft.wiki/w/Resource_Pack#Contents>
+/// - <https://minecraft.wiki/w/Data_Pack#pack.mcmeta>
 /// - Minecraft class `net.minecraft.server.packs.metadata.pack.PackMetadataSectionSerializer`
 /// - Minecraft class `net.minecraft.server.packs.resources.ResourceFilterSection`
 pub struct PackMeta {


### PR DESCRIPTION
## Motivation and purpose

The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. 

## Description

This PR updates al fandom wiki URLs accordingly.

## Notes

Other branches where fandom wiki links are: I10n/workspace/v0.5.0, workspace/v.4.0, and feat/web-ui
Would you like all of them to have the new wiki links?