### PR TITLE
fix: update CI build workflow reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -281,7 +281,7 @@ to produce a working debug executable. In reality, however, that will not work
 out of the box due to C libraries that depend on a properly configured platform
 C toolchain and development files. The best way to get these set up is to look
 at the [CI build
-workflow](https://github.com/ComunidadAylas/PackSquash/blob/master/.github/workflows/build.yml)
+workflow](https://github.com/ComunidadAylas/PackSquash/blob/master/.github/workflows/ci.yml)
 and replicate its steps on your machine.
 
 A corollary of the previously stated complications with C libraries is that your


### PR DESCRIPTION
# PR Summary
Small PR - Commit 2ee2db34247ea770d83be8e8339907dc1126ad64 renamed the CI build workflow. This PR adjusts sources to changes.