### PR TITLE
Finish adding support for `function` folder introduced in 24w21a.

### DIFF
--- a/packages/packsquash/src/squash_zip/obfuscation_engine/pseudodir_concealment.rs
+++ b/packages/packsquash/src/squash_zip/obfuscation_engine/pseudodir_concealment.rs
@@ -43,7 +43,7 @@ static KNOWN_LISTED_RESOURCE_PATTERNS: &[&str] = &[
 	// "data/*/tags/**/*.json"
 	"data/*/**/*.json",
 	"data/*/{structure,structures}/**/*.nbt",
-	"data/*/functions/**/*.mcfunction"
+	"data/*/{function,functions}/**/*.mcfunction"
 ];
 
 #[derive(Copy, Clone)]


### PR DESCRIPTION
Started using PackSquash to optimize the ZIP size of my [Hintful Advancements](https://modrinth.com/datapack/hintful-advancements) data pack. I saw that it didn't support overlays, so I force-included those folders. But what I didn't catch is that although it supported most of the renamed-to-singular folders introduced in 1.21, it *didn't* fully support the `function` folder, as I discovered the hard way.

This PR finishes adding support for the `function` folder.

See also: https://github.com/ComunidadAylas/PackSquash/commit/4b45e32eb91804c0fc670d8140c8e7bad3d9b2af
