### PR TITLE
version number support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2600,9 +2600,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",

--- a/packages/packsquash/src/pack_meta.rs
+++ b/packages/packsquash/src/pack_meta.rs
@@ -45,7 +45,7 @@ pub const PACK_FORMAT_DATA_PACK_VERSION_24W_21A: i32 = 45;
 /// - <https://minecraft.wiki/w/Data_Pack#pack.mcmeta>
 /// - Minecraft class `net.minecraft.server.packs.metadata.pack.PackMetadataSectionSerializer`
 pub struct PackMeta {
-	pack_format_version: i32
+	pack_format_version: f64
 }
 
 /// Represents an error that may happen while parsing pack metadata files.
@@ -65,8 +65,8 @@ impl PackMeta {
 		vfs: &impl VirtualFileSystem,
 		root_path: impl AsRef<Path>
 	) -> Result<Self, PackMetaError> {
-		const PACK_FORMAT_VERSION_IS_NOT_INTEGER: &str =
-			"\"pack_format\" version is not a Java integer";
+		const PACK_FORMAT_VERSION_IS_NOT_NUMBER: &str =
+			"\"pack_format\" version is not an integer or integer.integer number";
 
 		let pack_format_version;
 
@@ -94,22 +94,13 @@ impl PackMeta {
 							)
 						)? {
 							Value::Number(pack_format_version_number) => {
-								// Minecraft always reads this field as a Java integer,
-								// so a conversion to an i32 should be successful
-								pack_format_version = i32::try_from(
-									pack_format_version_number.as_i64().ok_or(
-										PackMetaError::MalformedMeta(
-											PACK_FORMAT_VERSION_IS_NOT_INTEGER
-										)
-									)?
-								)
-								.map_err(|_| {
-									PackMetaError::MalformedMeta(PACK_FORMAT_VERSION_IS_NOT_INTEGER)
-								})?;
+								pack_format_version = pack_format_version_number.as_f64().ok_or(
+									PackMetaError::MalformedMeta(PACK_FORMAT_VERSION_IS_NOT_NUMBER)
+								)?;
 							}
 							_ => {
 								return Err(PackMetaError::MalformedMeta(
-									PACK_FORMAT_VERSION_IS_NOT_INTEGER
+									PACK_FORMAT_VERSION_IS_NOT_NUMBER
 								));
 							}
 						};
@@ -166,14 +157,14 @@ impl PackMeta {
 	pub fn target_minecraft_versions_quirks(&self) -> EnumSet<MinecraftQuirk> {
 		let mut quirks = EnumSet::empty();
 
-		if self.pack_format_version < PACK_FORMAT_VERSION_1_13 {
+		if self.pack_format_version < f64::from(PACK_FORMAT_VERSION_1_13) {
 			quirks |= MinecraftQuirk::GrayscaleImagesGammaMiscorrection;
 			quirks |= MinecraftQuirk::RestrictiveBannerLayerTextureFormatCheck;
 			quirks |= MinecraftQuirk::PngObfuscationIncompatibility;
 		}
 
-		if self.pack_format_version < PACK_FORMAT_VERSION_1_15
-			|| self.pack_format_version >= PACK_FORMAT_RESOURCE_PACK_VERSION_24W_13A
+		if self.pack_format_version < f64::from(PACK_FORMAT_VERSION_1_15)
+			|| self.pack_format_version >= f64::from(PACK_FORMAT_RESOURCE_PACK_VERSION_24W_13A)
 		{
 			// Minecraft 1.14 is compatible with this feature, but we can't tell
 			// it apart from 1.13 due to it sharing the same version number, so
@@ -182,11 +173,11 @@ impl PackMeta {
 			quirks |= MinecraftQuirk::OggObfuscationIncompatibility;
 		}
 
-		if self.pack_format_version < PACK_FORMAT_VERSION_1_17 {
+		if self.pack_format_version < f64::from(PACK_FORMAT_VERSION_1_17) {
 			quirks |= MinecraftQuirk::Java8ZipParsing;
 		}
 
-		if self.pack_format_version < PACK_FORMAT_RESOURCE_PACK_VERSION_24W_40A {
+		if self.pack_format_version < f64::from(PACK_FORMAT_RESOURCE_PACK_VERSION_24W_40A) {
 			// 24w39a is the first snapshot to have this fixed, but we can't tell it
 			// apart from 24w38a due to it sharing the same pack format version number,
 			// so err on the safe side
@@ -209,26 +200,26 @@ impl PackMeta {
 	pub fn target_minecraft_version_asset_type_mask(&self) -> EnumSet<PackFileAssetType> {
 		let mut asset_type_mask = EnumSet::all();
 
-		if self.pack_format_version >= PACK_FORMAT_VERSION_1_13 {
+		if self.pack_format_version >= f64::from(PACK_FORMAT_VERSION_1_13) {
 			asset_type_mask -= PackFileAssetType::LegacyLanguageFile;
 			asset_type_mask -= PackFileAssetType::TrueTypeFont;
 		}
 
-		if self.pack_format_version >= PACK_FORMAT_VERSION_1_17 {
+		if self.pack_format_version >= f64::from(PACK_FORMAT_VERSION_1_17) {
 			asset_type_mask -= PackFileAssetType::LegacyTextCredits;
 		} else {
 			asset_type_mask -= PackFileAssetType::TranslationUnitSegment;
 		}
 
-		if self.pack_format_version < PACK_FORMAT_RESOURCE_PACK_VERSION_1_18 {
+		if self.pack_format_version < f64::from(PACK_FORMAT_RESOURCE_PACK_VERSION_1_18) {
 			asset_type_mask -= PackFileAssetType::ClosingCreditsText;
 		}
 
-		if self.pack_format_version >= PACK_FORMAT_RESOURCE_PACK_VERSION_23W_17A {
+		if self.pack_format_version >= f64::from(PACK_FORMAT_RESOURCE_PACK_VERSION_23W_17A) {
 			asset_type_mask -= PackFileAssetType::LegacyUnicodeFontCharacterSizes;
 		}
 
-		if self.pack_format_version >= PACK_FORMAT_DATA_PACK_VERSION_24W_21A {
+		if self.pack_format_version >= f64::from(PACK_FORMAT_DATA_PACK_VERSION_24W_21A) {
 			asset_type_mask -= PackFileAssetType::LegacyNbtStructure;
 			asset_type_mask -= PackFileAssetType::LegacyCommandFunction;
 		}

--- a/packages/packsquash/src/pack_meta/tests.rs
+++ b/packages/packsquash/src/pack_meta/tests.rs
@@ -145,6 +145,42 @@ async fn pack_mcmeta_with_missing_description() {
 }
 
 #[tokio::test]
+async fn well_formed_pack_mcmeta_with_float_pack_format_works() {
+	PackMeta::new(
+		&MockVfs(
+			r#"
+				{
+					"pack": {
+						"pack_format": 69.0,
+						"description": "My pack"
+					}
+				}"#
+		),
+		""
+	)
+	.await
+	.expect("Unexpected failure reading pack metadata");
+}
+
+#[tokio::test]
+async fn well_formed_pack_mcmeta_with_decimal_pack_format_works() {
+	PackMeta::new(
+		&MockVfs(
+			r#"
+				{
+					"pack": {
+						"pack_format": 69.5,
+						"description": "My pack"
+					}
+				}"#
+		),
+		""
+	)
+	.await
+	.expect("Unexpected failure reading pack metadata");
+}
+
+#[tokio::test]
 async fn pack_mcmeta_with_bad_pack_format() {
 	assert!(
 		PackMeta::new(
@@ -152,7 +188,7 @@ async fn pack_mcmeta_with_bad_pack_format() {
 				r#"
 					{
 						"pack": {
-							"pack_format": -0.5,
+							"pack_format": "69.5",
 							"description": "My bad pack"
 						}
 					}"#


### PR DESCRIPTION
## Background

PackSquash currently validates pack format values against an internal known range.  
For newer Minecraft versions, this can fail even when the pack itself is otherwise valid, which blocked our automated resource pack build pipeline.

Reference: [#373](https://github.com/ComunidadAylas/PackSquash/issues/373)

## Motivation and purpose

We use PackSquash in an automated resource pack builder.  
When Mojang introduces a new pack format value, strict validation can reject the pack until PackSquash is updated, causing build failures for users targeting new versions.

This change makes PackSquash more forward-compatible so that newly introduced pack format numbers do not immediately break automation workflows.

## Description

This PR updates pack metadata handling so newer/unknown pack format numbers are accepted in a compatible way instead of being treated as hard validation failures.

Implementation highlights:

- Adjusts pack format validation logic in the metadata path (see `pack_meta.rs`).
- Preserves existing behavior for known/validated formats.
- Improves resilience for future Minecraft releases where pack format values may be ahead of the currently known set.

Outcome:

- Automated builds can continue to run for newer Minecraft versions without waiting for an immediate PackSquash release bump for every new format number.

## Testing techniques and resources

Manual testing:

- Ran PackSquash against a resource pack declaring a newer pack format value that previously failed validation.
- Verified PackSquash no longer rejects the pack due to pack format number checks.
- Confirmed expected behavior remains unchanged for known/older pack format values.

Automated/local testing:

- Ran existing project tests locally (`cargo test`) and ensured they pass.
- Built the CLI locally and verified end-to-end execution with a sample pack.

(If you added/updated specific tests, list them here explicitly.)

## Usage

No user-facing CLI/API changes are required.

Users can continue using PackSquash as before, but now builds are less likely to break immediately when new Minecraft versions introduce new pack format numbers.

## Notes

- This change is intentionally focused on forward compatibility for pack format validation.
- If maintainers prefer stricter behavior, I’m happy to follow up with an option/flag to choose strict vs forward-compatible validation mode.