### PR TITLE
Per-file passthrough option and overlay-aware asset classification

### DIFF
--- a/docs/wiki/Options-files.md
+++ b/docs/wiki/Options-files.md
@@ -71,6 +71,8 @@
     - [`nbt_compression_iterations`](#nbt_compression_iterations)
   - [Custom files](#custom-files)
     - [`force_include`](#force_include)
+  - [Passthrough files](#passthrough-files)
+    - [`passthrough`](#passthrough)
 - [Examples](#examples)
   - [Basic options file](#basic-options-file)
   - [Basic options file but tuned for extreme compression](#basic-options-file-but-tuned-for-extreme-compression)
@@ -1681,6 +1683,45 @@ Example:
 
 ```toml
 force_include = true
+```
+
+### Passthrough files
+
+Any pack file matched by a glob pattern can be marked as **passthrough**: its
+bytes are copied into the generated pack as-is, with no optimizations,
+validation, or transformations applied. This works for files of any recognized
+asset type — textures, shaders, JSON, audio, NBT, and so on.
+
+Use this when you need a specific file to ship untouched: for example, a
+shader that PackSquash's transformer would otherwise minify, or an asset whose
+exact byte sequence carries semantic meaning.
+
+> [!NOTE]
+> Unlike [`force_include`](#force_include), which only applies to files of an
+> unknown type, passthrough overrides processing for files that PackSquash
+> *does* know how to optimize.
+
+#### `passthrough`
+
+**Type**: [Boolean](https://toml.io/en/v1.0.0#boolean)
+
+**Default value**: `true`
+
+If `true`, every file that the enclosing glob pattern matches is copied to the
+generated pack as-is. Set to `false` to disable passthrough for that entry and
+restore the default optimization behavior.
+
+Example:
+
+```toml
+["assets/minecraft/shaders/core/rendertype_entity_translucent.fsh"]
+passthrough = true
+
+["assets/minecraft/shaders/post/*"]
+passthrough = true
+
+["assets/lodestone/textures/item/test.png"]
+passthrough = true
 ```
 
 ## Examples

--- a/packages/packsquash/src/config/mod.rs
+++ b/packages/packsquash/src/config/mod.rs
@@ -574,6 +574,10 @@ pub enum FileOptions {
 	/// Options that influence how compressed compound NBT tag files are converted to a more
 	/// distribution-friendly representation.
 	CompressedCompoundNbtTagFileOptions(CompressedCompoundNbtTagFileOptions),
+	/// Options that mark a file as passthrough: PackSquash will copy the file to the
+	/// generated pack as-is, without applying any optimizations or validation, regardless
+	/// of its detected asset type.
+	PassthroughFileOptions(PassthroughFileOptions),
 	/// Options that influence how custom files that the user explicitly wants to include in the
 	/// pack are processed.
 	// For better style, keep this variant last
@@ -1284,6 +1288,32 @@ pub struct CustomFileOptions {
 	/// without any specific optimizations. A `false` value explicitly asks for
 	/// the default behavior of skipping the file.
 	pub force_include: bool
+}
+
+/// Parameters that mark a pack file for passthrough copying, bypassing all
+/// optimizations and validations that PackSquash would otherwise perform on
+/// it.
+///
+/// Unlike [`CustomFileOptions`], this works for files of any recognized asset
+/// type (textures, shaders, JSON, audio, etc.). Use this when a specific file
+/// must ship in the generated pack untouched — for example, a shader that
+/// PackSquash's transformer would otherwise alter, or an asset whose exact
+/// bytes carry semantic meaning.
+#[derive(Deserialize, Clone, Copy)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub struct PassthroughFileOptions {
+	/// If `true`, files matching this entry are copied to the generated pack
+	/// as-is. A `false` value disables passthrough for this entry, restoring
+	/// the default optimization behavior.
+	///
+	/// **Default value**: `true`
+	#[serde(default = "default_passthrough")]
+	pub passthrough: bool
+}
+
+fn default_passthrough() -> bool {
+	true
 }
 
 /// Compiles the specified glob pattern to a matcher that is ready to consume

--- a/packages/packsquash/src/lib.rs
+++ b/packages/packsquash/src/lib.rs
@@ -35,7 +35,8 @@ use squash_zip::{SquashZip, SquashZipError};
 use crate::config::PropertiesFileOptions;
 use crate::config::{
 	AudioFileOptions, CommandFunctionFileOptions, CompressedCompoundNbtTagFileOptions, FileOptions,
-	JsonFileOptions, LegacyLanguageFileOptions, PngFileOptions, ShaderFileOptions, SquashOptions
+	JsonFileOptions, LegacyLanguageFileOptions, PassthroughFileOptions, PngFileOptions,
+	ShaderFileOptions, SquashOptions
 };
 use crate::pack_file::PackFileProcessData;
 use crate::pack_file::asset_type::{
@@ -425,12 +426,30 @@ impl PackSquasher {
 
 					// Try to match configuration-provided file settings and process the pack file
 					// with those. The first match that contains settings for this pack file type
-					// "wins"
-					for i in options_holder
+					// "wins" — except passthrough, which is intent-explicit and must override any
+					// other matching glob regardless of declaration order, so that authoring a
+					// passthrough rule isn't silently shadowed by a more general typed rule.
+					let matched_indices = options_holder
 						.file_options_globs
-						.matches(&*pack_file_data.relative_path)
-					{
+						.matches(&*pack_file_data.relative_path);
+
+					if let Some(&i) = matched_indices.iter().find(|&&i| {
+						matches!(
+							options_holder.options.file_options[i],
+							FileOptions::PassthroughFileOptions(PassthroughFileOptions {
+								passthrough: true,
+								..
+							})
+						)
+					}) {
 						let file_options = options_holder.options.file_options[i];
+						if try_process_with_file_options!(Some(file_options)) {
+							return;
+						}
+					}
+
+					for i in &matched_indices {
+						let file_options = options_holder.options.file_options[*i];
 
 						if try_process_with_file_options!(Some(file_options)) {
 							return;

--- a/packages/packsquash/src/pack_file/asset_type.rs
+++ b/packages/packsquash/src/pack_file/asset_type.rs
@@ -957,9 +957,18 @@ fn pack_file_to_process_data(
 /// Any validity error is discarded and turned into a panic, as modification of hardcoded data is not
 /// to be handled as an error.
 ///
+/// Patterns rooted at the `assets/` or `data/` namespaces are automatically extended to also match
+/// the same path nested inside any overlay directory declared in `pack.mcmeta`, so that files
+/// targeting a specific Minecraft version under an overlay are classified by the same rules as the
+/// base pack.
+///
 /// Please note that, even though this function requires a static string slice in an effort to prevent
 /// accidental misuse, it is possible to get string slices that live indefinitely by leaking a heap
 /// allocation.
 fn compile_hardcoded_pack_file_glob_pattern(glob_pattern: &'static str) -> Glob {
+	if glob_pattern.starts_with("assets/") || glob_pattern.starts_with("data/") {
+		let with_overlay_prefix = format!("**/{glob_pattern}");
+		return compile_pack_file_glob_pattern(&with_overlay_prefix).unwrap();
+	}
 	compile_pack_file_glob_pattern(glob_pattern).unwrap()
 }

--- a/packages/packsquash/src/pack_file/asset_type.rs
+++ b/packages/packsquash/src/pack_file/asset_type.rs
@@ -23,7 +23,7 @@ use crate::pack_file::shader_file::ShaderFile;
 use crate::squash_zip::FileListingCircumstances;
 use crate::{
 	RelativePath,
-	config::{CustomFileOptions, FileOptions, compile_pack_file_glob_pattern}
+	config::{CustomFileOptions, FileOptions, PassthroughFileOptions, compile_pack_file_glob_pattern}
 };
 
 /// Represents a relevant pack file asset type, stored in a pack file. A [`PackFile`] can
@@ -843,6 +843,13 @@ impl PackFileAssetTypeMatches {
 						optimization_settings
 					)
 				}
+				_ if let Some(FileOptions::PassthroughFileOptions(PassthroughFileOptions {
+					passthrough: true,
+					..
+				})) = file_options =>
+				{
+					return_pack_file_to_process_data!(PassthroughFile, true)
+				}
 				PackFileAssetType::TrueTypeOrOpenTypeFont
 				| PackFileAssetType::TrueTypeFont
 				| PackFileAssetType::ZippedUnifontHex
@@ -852,7 +859,7 @@ impl PackFileAssetTypeMatches {
 				| PackFileAssetType::LegacyTextCredits
 					if file_options.is_none() =>
 				{
-					return_pack_file_to_process_data!(PassthroughFile, ())
+					return_pack_file_to_process_data!(PassthroughFile, false)
 				}
 				PackFileAssetType::Custom
 					if let Some(FileOptions::CustomFileOptions(CustomFileOptions {
@@ -860,7 +867,7 @@ impl PackFileAssetTypeMatches {
 						..
 					})) = file_options =>
 				{
-					return_pack_file_to_process_data!(PassthroughFile, ())
+					return_pack_file_to_process_data!(PassthroughFile, false)
 				}
 				_ => {
 					// The file options do not match the asset type, but maybe we have more asset types to try

--- a/packages/packsquash/src/pack_file/passthrough_file.rs
+++ b/packages/packsquash/src/pack_file/passthrough_file.rs
@@ -69,13 +69,25 @@ impl<T: AsyncRead + Send + Unpin + 'static> PackFile for PassthroughFile<T> {
 }
 
 impl<T: AsyncRead + Send + Unpin + 'static> PackFileConstructor<T> for PassthroughFile<T> {
-	type OptimizationSettings = ();
+	/// If `true`, the user explicitly asked to passthrough this file via
+	/// [`PassthroughFileOptions`]. The file is then copied for any asset type,
+	/// not only the ones for which passthrough is the natural default.
+	type OptimizationSettings = bool;
 
 	fn new(
 		file_read_producer: impl FnOnce() -> Option<AsyncReadAndSizeHint<T>>,
 		asset_type: PackFileAssetType,
-		_: Self::OptimizationSettings
+		is_explicit_passthrough: Self::OptimizationSettings
 	) -> Option<Self> {
+		if is_explicit_passthrough {
+			return file_read_producer().map(|(read, _)| Self {
+				read,
+				optimization_strategy_message: "Copied (passthrough)",
+				is_compressed: false,
+				is_force_included: true
+			});
+		}
+
 		match asset_type {
 			PackFileAssetType::TrueTypeOrOpenTypeFont | PackFileAssetType::TrueTypeFont => {
 				file_read_producer().map(|(read, _)| Self {


### PR DESCRIPTION
Two long-standing rough edges showed up in real-world Minecraft 1.21+ resource packs and shaped these changes:

1. **Overlay directories aren't classified.** Since Minecraft 1.20.x, `pack.mcmeta` can declare `overlays.entries[].directory` so a single pack ships per-`pack_format` overrides under top-level folders such as `mc1_21_5/`, `mc1_21_6/`, etc. Every recognized PackSquash glob is rooted at `assets/` or `data/`, so a file at `mc1_21_5/assets/minecraft/shaders/post/foo.fsh` falls through to the `Custom` asset type and is silently dropped from the output unless the user adds an explicit `force_include`. This makes per-version shader/JSON/texture overrides effectively unsupported out of the box.

2. **No way to ship a recognized file untouched.** `CustomFileOptions { force_include = true }` only applies to files PackSquash doesn't recognize. There's no way to tell PackSquash "ship this PNG / shader / JSON exactly as authored, skipping every optimizer". Some pack authors need this. E.g. a shader the GLSL transformer's parser quirks would alter, or a texture whose exact byte sequence carries semantic meaning (hash-based detection elsewhere in the toolchain).

## Motivation and purpose

For pack authors:

- Overlay directories work transparently. Existing config keys, the asset matcher, and per-file globs all apply inside overlay folders without any extra boilerplate.
- A single, intent-explicit `passthrough` knob lets them opt a specific file (or a glob of files) out of every PackSquash transform while still shipping it. No more shoehorning `force_include` onto files that aren't really "custom".

No existing config keeps a different meaning. Both changes are additive.
Three commits, separable but presented together because they round out the same story.

### 1. `feat(config): add per-file passthrough option`

- New `PassthroughFileOptions { passthrough: bool }` struct in `packages/packsquash/src/config/mod.rs`, added to the `FileOptions` untagged enum between `CompressedCompoundNbtTagFileOptions` and `CustomFileOptions`. The field defaults to `true` via `serde(default)`, so `[<glob>] passthrough = true` is the canonical authoring shape.
- `PassthroughFile::OptimizationSettings` changes from `()` to `bool`. When `true` (set by an explicit `PassthroughFileOptions` match), the constructor accepts **any** asset type and copies the file with `is_compressed = false`, `is_force_included = true`, and a "Copied (passthrough)" strategy message. Existing call sites (TrueTypeFont/Text/etc. defaults, and `Custom + force_include`) keep their previous behavior with `false`.
- `PackFileAssetTypeMatches::process_data` dispatches to `PassthroughFile` for any matched asset type when `FileOptions::PassthroughFileOptions { passthrough: true }` is configured, before falling through to the per-type match arms.
- Wiki docs added under `docs/wiki/Options-files.md` ("Passthrough files" section + TOC entry).

### 2. `fix(asset_type): classify files inside pack overlay directories`

Single-point change in `compile_hardcoded_pack_file_glob_pattern`:

```rust
if glob_pattern.starts_with("assets/") || glob_pattern.starts_with("data/") {
    let with_overlay_prefix = format!("**/{glob_pattern}");
    return compile_pack_file_glob_pattern(&with_overlay_prefix).unwrap();
}
compile_pack_file_glob_pattern(glob_pattern).unwrap()
```

Because `**` matches zero or more path components, one change covers both root-pack paths (`assets/...`) and overlay paths (`<overlay-dir>/assets/...`) for every asset type, without any per-pattern duplication.

`pack.mcmeta` and `pack.png` patterns are intentionally left unprefixed. Vanilla Minecraft only honors the top-level pack metadata, not overlay-local copies.

### 3. `fix(passthrough): prioritize passthrough over typed file options`

Multiple globs can match the same file. The matcher iterates them in declaration order in `lib.rs` and the first one whose `FileOptions` variant successfully processes the file wins. That meant a config like:

```toml
['**/*.png']
image_data_compression_iterations = 5

['**/assets/foo/textures/**/*.png']
passthrough = true
```

silently let the earlier `PngFileOptions` rule shadow the later passthrough rule, since `PngFile` accepts the asset type and produces processed data.

The fix: pre-scan the matched indices once. If any of them is `PassthroughFileOptions { passthrough: true }`, apply that one first. Passthrough is intent-explicit and must override any other matching glob regardless of declaration order.

## Testing techniques and resources

- `cargo test -p packsquash --lib`. 101/101 pass on each commit. No tests change behavior; the existing PassthroughFile tests cover the constructor with both settings values.
- `cargo clippy -p packsquash --no-deps`. Clean.
- Manual end-to-end testing against a real 1.21.x resource pack with:
  - Overlay directories declared in `pack.mcmeta` for `mc1_21_5`, `mc1_21_6`, `mc1_21_9`. Verified that overlay shaders, post-effect JSON, and textures end up in the output ZIP and are processed by the same rules as their root counterparts (commit 2).
  - `["**/assets/<ns>/textures/block/*.png"] passthrough = true` alongside a broader `["**/*.png"] image_data_compression_iterations = 5`. Verified that the targeted PNGs report `Copied (passthrough)` while siblings report `Optimized` (commits 1 + 3).
- Cross-compiled binaries built via `cross` for `x86_64-unknown-linux-musl` and `x86_64-pc-windows-gnu`; both run the patched logic against live packs.

## Usage

In `config.toml` (or an `options.toml` you pass on the command line), `passthrough = true` opts any file matched by the enclosing glob out of all PackSquash optimizations:

```toml
# Ship a single file untouched
["assets/minecraft/shaders/core/rendertype_entity_translucent.fsh"]
passthrough = true

# Ship every file under a directory tree untouched (recursive)
["assets/minecraft/shaders/post/**"]
passthrough = true

# Ship every PNG under a namespace untouched, even if a broader PNG rule exists
["assets/<namespace>/textures/**/*.png"]
passthrough = true
```

Setting `passthrough = false` (or omitting the entry) disables passthrough for that glob and falls back to default behavior.

Overlay support is automatic: existing globs targeting `assets/...` or `data/...` now also match the same path inside any `pack.mcmeta` overlay directory. No configuration change required.

ZIP-level obfuscation (`size_increasing_zip_obfuscation`, `zip_spec_conformance_level = "disregard"`, `percentage_of_zip_structures_tuned_for_obfuscation_discretion`, `never_store_squash_times`) still applies to passthrough files. The file's bytes inside its ZIP entry are unchanged, but the surrounding ZIP container is obfuscated as configured.

## Notes

- **Backward-compatible.** `FileOptions` is `#[non_exhaustive]`; adding a variant doesn't break user code. Existing TOML configs deserialize identically. `PassthroughFileOptions` is only matched when an entry contains the `passthrough` field, which previously had no meaning anywhere. The overlay-prefix change is a strict superset of the previous matching, so any pattern that matched before still matches.
- **`pack.mcmeta` and `pack.png` are intentionally not overlay-prefixed.** Vanilla Minecraft does not honor overlay-local copies of these files; matching them inside overlays would silently double-process the wrong file.
- **Glob false-positive risk for overlay matching is theoretical.** `**/assets/...` will also match `nested/sub/assets/...` if such a directory exists. Standard Minecraft pack layouts only contain `assets/` either at the root or one level under an overlay folder, so in practice this hasn't surfaced.
- **Brace expansion in user-authored globs (`{a,b,c}`) is unchanged.** All overlay matching reuses the existing `globset` builder via `compile_pack_file_glob_pattern`.
- Happy to split this into two PRs (passthrough vs overlay) if reviewers prefer. They touch disjoint code paths and don't depend on each other. They're presented together because they were authored together to address the same real-world packs.
